### PR TITLE
Implement building placement system

### DIFF
--- a/Source/GardenSandbox/BuildingComponent.cpp
+++ b/Source/GardenSandbox/BuildingComponent.cpp
@@ -1,0 +1,254 @@
+#include "BuildingComponent.h"
+#include "GardenSandboxCharacter.h"
+#include "EnhancedInputComponent.h"
+#include "EnhancedInputSubsystems.h"
+#include "Engine/LocalPlayer.h"
+#include "InputActionValue.h"
+#include "GameFramework/PlayerController.h"
+#include "Camera/CameraComponent.h"
+#include "Components/PrimitiveComponent.h"
+#include "Materials/MaterialInterface.h"
+#include "Components/MeshComponent.h"
+
+UBuildingComponent::UBuildingComponent()
+{
+    PrimaryComponentTick.bCanEverTick = true;
+    GhostActor = nullptr;
+    Character = nullptr;
+    bIsPlacing = false;
+    CurrentYaw = 0.f;
+    bPlacementValid = true;
+}
+
+void UBuildingComponent::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+bool UBuildingComponent::AttachComponent(AGardenSandboxCharacter* TargetCharacter)
+{
+    Character = TargetCharacter;
+
+    if (Character == nullptr || Character->GetInstanceComponents().FindItemByClass<UBuildingComponent>())
+    {
+        return false;
+    }
+
+    if (APlayerController* PlayerController = Cast<APlayerController>(Character->GetController()))
+    {
+        if (UEnhancedInputLocalPlayerSubsystem* Subsystem = ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(PlayerController->GetLocalPlayer()))
+        {
+            Subsystem->AddMappingContext(BuildMappingContext, 1);
+        }
+
+        if (UEnhancedInputComponent* EnhancedInputComponent = Cast<UEnhancedInputComponent>(PlayerController->InputComponent))
+        {
+            EnhancedInputComponent->BindAction(StartBuildingAction, ETriggerEvent::Triggered, this, &UBuildingComponent::StartPlacement);
+            EnhancedInputComponent->BindAction(PlaceAction, ETriggerEvent::Triggered, this, &UBuildingComponent::Place);
+            EnhancedInputComponent->BindAction(CancelAction, ETriggerEvent::Triggered, this, &UBuildingComponent::Cancel);
+            if (RotateAction)
+            {
+                EnhancedInputComponent->BindAction(RotateAction, ETriggerEvent::Triggered, this, &UBuildingComponent::Rotate);
+            }
+        }
+    }
+
+    return true;
+}
+
+void UBuildingComponent::StartPlacement()
+{
+    if (bIsPlacing || !BuildingClass)
+    {
+        return;
+    }
+
+    UWorld* World = GetWorld();
+    if (!World)
+    {
+        return;
+    }
+
+    GhostActor = World->SpawnActor<AActor>(BuildingClass, FVector::ZeroVector, FRotator::ZeroRotator);
+    if (GhostActor)
+    {
+        GhostActor->SetActorEnableCollision(false);
+        TArray<UActorComponent*> Comps;
+        GhostActor->GetComponents(UPrimitiveComponent::StaticClass(), Comps);
+        for (UActorComponent* Comp : Comps)
+        {
+            if (UPrimitiveComponent* Prim = Cast<UPrimitiveComponent>(Comp))
+            {
+                Prim->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+            }
+        }
+        GhostActor->GetComponents<UMeshComponent>(GhostMeshComponents);
+        UpdateGhostVisual();
+        bIsPlacing = true;
+        CurrentYaw = 0.f;
+    }
+}
+
+void UBuildingComponent::Place()
+{
+    if (!bIsPlacing || !GhostActor || !BuildingClass)
+    {
+        return;
+    }
+
+    FVector Loc = GhostActor->GetActorLocation();
+    FRotator Rot = GhostActor->GetActorRotation();
+    GhostActor->Destroy();
+    GhostActor = nullptr;
+    GhostMeshComponents.Empty();
+    bPlacementValid = true;
+
+    if (UWorld* World = GetWorld())
+    {
+        World->SpawnActor<AActor>(BuildingClass, Loc, Rot);
+    }
+
+    bIsPlacing = false;
+}
+
+void UBuildingComponent::Cancel()
+{
+    if (bIsPlacing)
+    {
+        if (GhostActor)
+        {
+            GhostActor->Destroy();
+            GhostActor = nullptr;
+        }
+        GhostMeshComponents.Empty();
+        bPlacementValid = true;
+        bIsPlacing = false;
+    }
+}
+
+void UBuildingComponent::Rotate()
+{
+    if (bIsPlacing)
+    {
+        CurrentYaw += RotationStep;
+        if (CurrentYaw > 360.f)
+        {
+            CurrentYaw -= 360.f;
+        }
+    }
+}
+
+void UBuildingComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+    Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+    if (bIsPlacing && GhostActor && Character)
+    {
+        FVector CamLoc;
+        FRotator CamRot;
+        Character->GetActorEyesViewPoint(CamLoc, CamRot);
+
+        FVector TraceStart = CamLoc;
+        FVector TraceEnd = CamLoc + CamRot.Vector() * 1000.f;
+
+        FHitResult Hit;
+        FCollisionQueryParams Params;
+        Params.AddIgnoredActor(Character);
+
+        if (GetWorld()->LineTraceSingleByChannel(Hit, TraceStart, TraceEnd, ECC_Visibility, Params))
+        {
+            FVector Loc = Hit.Location;
+            if (GridSize > 0.f)
+            {
+                Loc.X = FMath::GridSnap(Loc.X, GridSize);
+                Loc.Y = FMath::GridSnap(Loc.Y, GridSize);
+                Loc.Z = FMath::GridSnap(Loc.Z, GridSize);
+            }
+            GhostActor->SetActorLocation(Loc);
+        }
+        else
+        {
+            FVector Loc = TraceEnd;
+            if (GridSize > 0.f)
+            {
+                Loc.X = FMath::GridSnap(Loc.X, GridSize);
+                Loc.Y = FMath::GridSnap(Loc.Y, GridSize);
+                Loc.Z = FMath::GridSnap(Loc.Z, GridSize);
+            }
+            GhostActor->SetActorLocation(Loc);
+        }
+
+        GhostActor->SetActorRotation(FRotator(0.f, CamRot.Yaw + CurrentYaw, 0.f));
+
+        UpdateGhostVisual();
+    }
+}
+
+void UBuildingComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    if (bIsPlacing)
+    {
+        Cancel();
+    }
+
+    if (Character)
+    {
+        if (APlayerController* PlayerController = Cast<APlayerController>(Character->GetController()))
+        {
+            if (UEnhancedInputLocalPlayerSubsystem* Subsystem = ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(PlayerController->GetLocalPlayer()))
+            {
+                Subsystem->RemoveMappingContext(BuildMappingContext);
+            }
+        }
+    }
+
+    Super::EndPlay(EndPlayReason);
+}
+
+void UBuildingComponent::UpdateGhostVisual()
+{
+    if (!GhostActor)
+    {
+        return;
+    }
+
+    FVector Origin;
+    FVector BoxExtent;
+    GhostActor->GetActorBounds(true, Origin, BoxExtent);
+    FCollisionShape Box = FCollisionShape::MakeBox(BoxExtent);
+
+    FCollisionQueryParams Params;
+    Params.AddIgnoredActor(GhostActor);
+    if (Character)
+    {
+        Params.AddIgnoredActor(Character);
+    }
+
+    FCollisionObjectQueryParams ObjParams;
+    ObjParams.AddObjectTypesToQuery(ECC_WorldStatic);
+    ObjParams.AddObjectTypesToQuery(ECC_WorldDynamic);
+    ObjParams.AddObjectTypesToQuery(ECC_Pawn);
+
+    bool bNewValid = !GetWorld()->OverlapAnyTestByObjectType(Origin, FQuat::Identity, ObjParams, Box, Params);
+    if (bPlacementValid != bNewValid)
+    {
+        bPlacementValid = bNewValid;
+        for (UMeshComponent* Mesh : GhostMeshComponents)
+        {
+            if (!Mesh)
+            {
+                continue;
+            }
+            UMaterialInterface* Mat = bPlacementValid ? ValidPlacementMaterial : InvalidPlacementMaterial;
+            if (Mat)
+            {
+                int32 Count = Mesh->GetNumMaterials();
+                for (int32 i = 0; i < Count; ++i)
+                {
+                    Mesh->SetMaterial(i, Mat);
+                }
+            }
+        }
+    }
+}
+

--- a/Source/GardenSandbox/BuildingComponent.h
+++ b/Source/GardenSandbox/BuildingComponent.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "BuildingComponent.generated.h"
+
+class AGardenSandboxCharacter;
+class UInputAction;
+class UInputMappingContext;
+class UMaterialInterface;
+class UMeshComponent;
+
+UCLASS(Blueprintable, BlueprintType, ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class GARDENSANDBOX_API UBuildingComponent : public UActorComponent
+{
+    GENERATED_BODY()
+
+public:
+    UBuildingComponent();
+
+    /** Size of the placement grid. Set to 0 for no snapping */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Building")
+    float GridSize = 100.f;
+
+    /** Additional yaw rotation applied to the ghost */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Building")
+    float RotationStep = 90.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Building")
+    TSubclassOf<AActor> BuildingClass;
+
+    /** Material used when placement is valid */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Building|Visual")
+    UMaterialInterface* ValidPlacementMaterial;
+
+    /** Material used when placement is invalid */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Building|Visual")
+    UMaterialInterface* InvalidPlacementMaterial;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=Input, meta=(AllowPrivateAccess="true"))
+    UInputMappingContext* BuildMappingContext;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=Input, meta=(AllowPrivateAccess="true"))
+    UInputAction* StartBuildingAction;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=Input, meta=(AllowPrivateAccess="true"))
+    UInputAction* PlaceAction;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=Input, meta=(AllowPrivateAccess="true"))
+    UInputAction* CancelAction;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=Input, meta=(AllowPrivateAccess="true"))
+    UInputAction* RotateAction;
+
+    bool AttachComponent(AGardenSandboxCharacter* TargetCharacter);
+
+    void StartPlacement();
+    void Place();
+    void Cancel();
+    void Rotate();
+
+protected:
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+    virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+private:
+    AActor* GhostActor;
+    AGardenSandboxCharacter* Character;
+    bool bIsPlacing;
+    float CurrentYaw;
+    TArray<UMeshComponent*> GhostMeshComponents;
+    bool bPlacementValid;
+
+    void UpdateGhostVisual();
+};
+

--- a/Source/GardenSandbox/GardenBuildingBase.cpp
+++ b/Source/GardenSandbox/GardenBuildingBase.cpp
@@ -1,0 +1,10 @@
+#include "GardenBuildingBase.h"
+#include "Components/StaticMeshComponent.h"
+
+AGardenBuildingBase::AGardenBuildingBase()
+{
+    PrimaryActorTick.bCanEverTick = false;
+
+    MeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("MeshComponent"));
+    RootComponent = MeshComponent;
+}

--- a/Source/GardenSandbox/GardenBuildingBase.h
+++ b/Source/GardenSandbox/GardenBuildingBase.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "GardenBuildingBase.generated.h"
+
+UCLASS()
+class GARDENSANDBOX_API AGardenBuildingBase : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AGardenBuildingBase();
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+    UStaticMeshComponent* MeshComponent;
+};
+

--- a/Source/GardenSandbox/GardenSandboxCharacter.cpp
+++ b/Source/GardenSandbox/GardenSandboxCharacter.cpp
@@ -6,6 +6,7 @@
 #include "Camera/CameraComponent.h"
 #include "Components/CapsuleComponent.h"
 #include "Components/SkeletalMeshComponent.h"
+#include "BuildingComponent.h"
 #include "EnhancedInputComponent.h"
 #include "EnhancedInputSubsystems.h"
 #include "InputActionValue.h"
@@ -32,9 +33,12 @@ AGardenSandboxCharacter::AGardenSandboxCharacter()
 	Mesh1P->SetupAttachment(FirstPersonCameraComponent);
 	Mesh1P->bCastDynamicShadow = false;
 	Mesh1P->CastShadow = false;
-	Mesh1P->SetRelativeLocation(FVector(-30.f, 0.f, -150.f));
-	
-	// Stellen Sie sicher, dass das 1P-Mesh nur der Owner sieht
+       Mesh1P->SetRelativeLocation(FVector(-30.f, 0.f, -150.f));
+
+        // Create building component
+        BuildingComponent = CreateDefaultSubobject<UBuildingComponent>(TEXT("BuildingComponent"));
+
+        // Stellen Sie sicher, dass das 1P-Mesh nur der Owner sieht
 	Mesh1P->SetOnlyOwnerSee(true);
 	//Mesh1P->SetOwnerNoSee(false);
 
@@ -51,16 +55,21 @@ void AGardenSandboxCharacter::GetLifetimeReplicatedProps(TArray<FLifetimePropert
 
 void AGardenSandboxCharacter::NotifyControllerChanged()
 {
-	Super::NotifyControllerChanged();
+        Super::NotifyControllerChanged();
 
-	// Add Input Mapping Context
-	if (APlayerController* PlayerController = Cast<APlayerController>(GetController()))
-	{
-		if (UEnhancedInputLocalPlayerSubsystem* Subsystem = ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(PlayerController->GetLocalPlayer()))
-		{
-			Subsystem->AddMappingContext(DefaultMappingContext, 0);
-		}
-	}
+        // Add Input Mapping Context
+        if (APlayerController* PlayerController = Cast<APlayerController>(GetController()))
+        {
+                if (UEnhancedInputLocalPlayerSubsystem* Subsystem = ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(PlayerController->GetLocalPlayer()))
+                {
+                        Subsystem->AddMappingContext(DefaultMappingContext, 0);
+                }
+        }
+
+        if (BuildingComponent)
+        {
+                BuildingComponent->AttachComponent(this);
+        }
 }
 
 void AGardenSandboxCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)

--- a/Source/GardenSandbox/GardenSandboxCharacter.h
+++ b/Source/GardenSandbox/GardenSandboxCharacter.h
@@ -14,6 +14,7 @@ class UCameraComponent;
 class UInputAction;
 class UInputMappingContext;
 struct FInputActionValue;
+class UBuildingComponent;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogTemplateCharacter, Log, All);
 
@@ -23,8 +24,8 @@ class AGardenSandboxCharacter : public ACharacter
 	GENERATED_BODY()
 
 	/** Pawn mesh: 1st person view (arms; seen only by self) */
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category=Mesh, meta = (AllowPrivateAccess = "true"))
-	USkeletalMeshComponent* Mesh1P;
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category=Mesh, meta = (AllowPrivateAccess = "true"))
+        USkeletalMeshComponent* Mesh1P;
 
 	/** First person camera */
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera, meta = (AllowPrivateAccess = "true"))
@@ -44,7 +45,11 @@ class AGardenSandboxCharacter : public ACharacter
 
 	/** Look Input Action */
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
-	class UInputAction* LookAction;
+        class UInputAction* LookAction;
+
+        /** Building Component */
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Building, meta = (AllowPrivateAccess = "true"))
+        UBuildingComponent* BuildingComponent;
 	
 
 	


### PR DESCRIPTION
## Summary
- add simple BuildingComponent for ghost placement and building spawning
- create basic GardenBuildingBase actor
- integrate BuildingComponent into GardenSandboxCharacter
- add visual feedback materials for valid/invalid building placement

## Testing
- `ls Source/GardenSandbox`


------
https://chatgpt.com/codex/tasks/task_e_68414772bf4c8331a778a068197753f1