### PR TITLE
Add hitbox setup for character mesh

### DIFF
--- a/Source/GardenSandbox/DamageTypes.cpp
+++ b/Source/GardenSandbox/DamageTypes.cpp
@@ -1,0 +1,3 @@
+#include "DamageTypes.h"
+
+// Intentionally empty - damage types only serve as identifiers

--- a/Source/GardenSandbox/DamageTypes.h
+++ b/Source/GardenSandbox/DamageTypes.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/DamageType.h"
+#include "DamageTypes.generated.h"
+
+/** DamageType representing fire damage */
+UCLASS()
+class GARDENSANDBOX_API UFireDamageType : public UDamageType
+{
+    GENERATED_BODY()
+};
+
+/** DamageType representing frost damage */
+UCLASS()
+class GARDENSANDBOX_API UFrostDamageType : public UDamageType
+{
+    GENERATED_BODY()
+};
+
+/** DamageType representing poison damage */
+UCLASS()
+class GARDENSANDBOX_API UPoisonDamageType : public UDamageType
+{
+    GENERATED_BODY()
+};
+

--- a/Source/GardenSandbox/GardenBuildingBase.cpp
+++ b/Source/GardenSandbox/GardenBuildingBase.cpp
@@ -1,5 +1,6 @@
 #include "GardenBuildingBase.h"
 #include "Components/StaticMeshComponent.h"
+#include "HealthComponent.h"
 
 AGardenBuildingBase::AGardenBuildingBase()
 {
@@ -7,4 +8,6 @@ AGardenBuildingBase::AGardenBuildingBase()
 
     MeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("MeshComponent"));
     RootComponent = MeshComponent;
+
+    HealthComponent = CreateDefaultSubobject<UHealthComponent>(TEXT("HealthComponent"));
 }

--- a/Source/GardenSandbox/GardenBuildingBase.h
+++ b/Source/GardenSandbox/GardenBuildingBase.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
+#include "HealthComponent.h"
 #include "GardenBuildingBase.generated.h"
 
 UCLASS()
@@ -14,6 +15,9 @@ public:
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
     UStaticMeshComponent* MeshComponent;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+    UHealthComponent* HealthComponent;
 
 };
 

--- a/Source/GardenSandbox/GardenSandboxCharacter.cpp
+++ b/Source/GardenSandbox/GardenSandboxCharacter.cpp
@@ -8,6 +8,8 @@
 #include "Components/SkeletalMeshComponent.h"
 #include "BuildingComponent.h"
 #include "ResourceComponent.h"
+#include "HealthComponent.h"
+#include "Engine/CollisionProfile.h"
 #include "EnhancedInputComponent.h"
 #include "EnhancedInputSubsystems.h"
 #include "InputActionValue.h"
@@ -39,8 +41,11 @@ AGardenSandboxCharacter::AGardenSandboxCharacter()
         // Create building component
         BuildingComponent = CreateDefaultSubobject<UBuildingComponent>(TEXT("BuildingComponent"));
 
-        // Create resource component
-        ResourceComponent = CreateDefaultSubobject<UResourceComponent>(TEXT("ResourceComponent"));
+    // Create resource component
+    ResourceComponent = CreateDefaultSubobject<UResourceComponent>(TEXT("ResourceComponent"));
+
+    // Create health component
+    HealthComponent = CreateDefaultSubobject<UHealthComponent>(TEXT("HealthComponent"));
 
         // Stellen Sie sicher, dass das 1P-Mesh nur der Owner sieht
 	Mesh1P->SetOnlyOwnerSee(true);
@@ -107,13 +112,35 @@ void AGardenSandboxCharacter::Move(const FInputActionValue& Value)
 
 void AGardenSandboxCharacter::Look(const FInputActionValue& Value)
 {
-	// input is a Vector2D
-	FVector2D LookAxisVector = Value.Get<FVector2D>();
+        // input is a Vector2D
+        FVector2D LookAxisVector = Value.Get<FVector2D>();
 
 	if (GetController() != nullptr)
 	{
 		// add yaw and pitch input to controller
-		AddControllerYawInput(LookAxisVector.X);
-		AddControllerPitchInput(LookAxisVector.Y);
-	}
+                AddControllerYawInput(LookAxisVector.X);
+                AddControllerPitchInput(LookAxisVector.Y);
+        }
+}
+
+void AGardenSandboxCharacter::BeginPlay()
+{
+        Super::BeginPlay();
+
+        SetupHitboxes();
+}
+
+void AGardenSandboxCharacter::SetupHitboxes()
+{
+        USkeletalMeshComponent* ThirdPersonMesh = GetMesh();
+        if (!ThirdPersonMesh)
+        {
+                return;
+        }
+
+        ThirdPersonMesh->SetCollisionProfileName(TEXT("Pawn"));
+        ThirdPersonMesh->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+        ThirdPersonMesh->SetGenerateOverlapEvents(true);
+        ThirdPersonMesh->SetNotifyRigidBodyCollision(true);
+        ThirdPersonMesh->SetAllBodiesNotifyRigidBodyCollision(true);
 }

--- a/Source/GardenSandbox/GardenSandboxCharacter.h
+++ b/Source/GardenSandbox/GardenSandboxCharacter.h
@@ -15,6 +15,7 @@ class UInputMappingContext;
 struct FInputActionValue;
 class UBuildingComponent;
 class UResourceComponent;
+class UHealthComponent;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogTemplateCharacter, Log, All);
 
@@ -54,17 +55,27 @@ class AGardenSandboxCharacter : public ACharacter
         /** Holds resources for the character */
         UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Resources, meta = (AllowPrivateAccess = "true"))
         UResourceComponent* ResourceComponent;
+
+        /** Tracks the character's health */
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Health, meta = (AllowPrivateAccess = "true"))
+        UHealthComponent* HealthComponent;
 	
 
 	
 public:
         AGardenSandboxCharacter();
 protected:
-	/** Called for movement input */
-	void Move(const FInputActionValue& Value);
+        /** Called for movement input */
+        void Move(const FInputActionValue& Value);
 
-	/** Called for looking input */
-	void Look(const FInputActionValue& Value);
+        /** Called for looking input */
+        void Look(const FInputActionValue& Value);
+
+        /** Called when the actor begins play to configure hitboxes */
+        virtual void BeginPlay() override;
+
+        /** Setup collision using the mesh's physics asset */
+        void SetupHitboxes();
 
 protected:
 	// APawn interface

--- a/Source/GardenSandbox/HealthComponent.cpp
+++ b/Source/GardenSandbox/HealthComponent.cpp
@@ -1,0 +1,67 @@
+#include "HealthComponent.h"
+#include "Net/UnrealNetwork.h"
+
+UHealthComponent::UHealthComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+    SetIsReplicatedByDefault(true);
+}
+
+void UHealthComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    Health = MaxHealth;
+
+    if (AActor* Owner = GetOwner())
+    {
+        Owner->OnTakeAnyDamage.AddDynamic(this, &UHealthComponent::HandleTakeAnyDamage);
+    }
+}
+
+void UHealthComponent::Heal(float Amount)
+{
+    if (Amount <= 0.f || Health <= 0.f)
+    {
+        return;
+    }
+
+    Health = FMath::Clamp(Health + Amount, 0.f, MaxHealth);
+}
+
+void UHealthComponent::HandleTakeAnyDamage(AActor* DamagedActor, float Damage, const UDamageType* DamageType, AController* InstigatedBy, AActor* DamageCauser)
+{
+    if (Damage <= 0.f || Health <= 0.f)
+    {
+        return;
+    }
+
+    float ActualDamage = Damage;
+    if (DamageType)
+    {
+        for (const FDamageMultiplier& Mult : DamageMultipliers)
+        {
+            if (DamageType->IsA(Mult.DamageType))
+            {
+                ActualDamage *= Mult.Multiplier;
+                break;
+            }
+        }
+    }
+
+    Health = FMath::Clamp(Health - ActualDamage, 0.f, MaxHealth);
+}
+
+void UHealthComponent::OnRep_Health()
+{
+    // Could trigger UI updates here
+}
+
+void UHealthComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+    DOREPLIFETIME(UHealthComponent, Health);
+    DOREPLIFETIME(UHealthComponent, DamageMultipliers);
+}
+

--- a/Source/GardenSandbox/HealthComponent.h
+++ b/Source/GardenSandbox/HealthComponent.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "GameFramework/DamageType.h"
+#include "HealthComponent.generated.h"
+
+USTRUCT(BlueprintType)
+struct FDamageMultiplier
+{
+    GENERATED_BODY()
+
+    /** DamageType affected by this multiplier */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Damage")
+    TSubclassOf<UDamageType> DamageType = UDamageType::StaticClass();
+
+    /** Multiplier applied to incoming damage of the given type */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Damage")
+    float Multiplier = 1.f;
+};
+
+UCLASS(Blueprintable, BlueprintType, ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class GARDENSANDBOX_API UHealthComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UHealthComponent();
+
+    /** Maximum health value */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Health")
+    float MaxHealth = 100.f;
+
+    /** Current health replicated to clients */
+    UPROPERTY(ReplicatedUsing=OnRep_Health, VisibleAnywhere, BlueprintReadOnly, Category="Health")
+    float Health = 100.f;
+
+    /** Multipliers for specific damage types */
+    UPROPERTY(Replicated, EditAnywhere, BlueprintReadWrite, Category="Damage")
+    TArray<FDamageMultiplier> DamageMultipliers;
+
+    /** Check whether the actor is still alive */
+    UFUNCTION(BlueprintCallable, Category="Health")
+    bool IsAlive() const { return Health > 0.f; }
+
+    /** Apply healing */
+    UFUNCTION(BlueprintCallable, Category="Health")
+    void Heal(float Amount);
+
+protected:
+    virtual void BeginPlay() override;
+
+    UFUNCTION()
+    void OnRep_Health();
+
+    UFUNCTION()
+    void HandleTakeAnyDamage(AActor* DamagedActor, float Damage, const UDamageType* DamageType, AController* InstigatedBy, AActor* DamageCauser);
+
+public:
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+};
+


### PR DESCRIPTION
## Summary
- configure the 3rd person mesh to use its physics asset for hit detection
- expose `BeginPlay` and `SetupHitboxes` on `AGardenSandboxCharacter`

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6841ae45179883319769ee8f57c6f447