### PR TITLE
Define FOnPickUp delegate

### DIFF
--- a/Source/GardenSandbox/GardenSandboxPickUpComponent.cpp
+++ b/Source/GardenSandbox/GardenSandboxPickUpComponent.cpp
@@ -30,6 +30,8 @@ void UGardenSandboxPickUpComponent::OnSphereBeginOverlap(UPrimitiveComponent* Ov
                         Character->ResourceComponent->AddResource(ResourceType, ResourceAmount);
                 }
 
+                // Notify listeners that this pickup has been collected
+                OnPickUp.Broadcast();
 
                 // Unregister from the Overlap Event so it is no longer triggered
                 OnComponentBeginOverlap.RemoveAll(this);

--- a/Source/GardenSandbox/GardenSandboxPickUpComponent.h
+++ b/Source/GardenSandbox/GardenSandboxPickUpComponent.h
@@ -10,6 +10,9 @@
 
 enum class EResourceType : uint8;
 
+/** Delegate for pickup events */
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnPickUp);
+
 UCLASS(Blueprintable, BlueprintType, ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
 class GARDENSANDBOX_API UGardenSandboxPickUpComponent : public USphereComponent
 {


### PR DESCRIPTION
## Summary
- define dynamic multicast delegate `FOnPickUp`
- broadcast pickup event when component overlap happens

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ccaaaad483318ab0512615f57dd1