### PR TITLE
Expose building input options on character

### DIFF
--- a/Source/GardenSandbox/GardenSandboxCharacter.cpp
+++ b/Source/GardenSandbox/GardenSandboxCharacter.cpp
@@ -69,10 +69,15 @@ void AGardenSandboxCharacter::NotifyControllerChanged()
                 }
         }
 
-        if (BuildingComponent)
-        {
+       if (BuildingComponent)
+       {
+                BuildingComponent->BuildMappingContext = BuildMappingContext;
+                BuildingComponent->StartBuildingAction = StartBuildingAction;
+                BuildingComponent->PlaceAction = PlaceBuildingAction;
+                BuildingComponent->CancelAction = CancelBuildingAction;
+                BuildingComponent->RotateAction = RotateBuildingAction;
                 BuildingComponent->AttachComponent(this);
-        }
+       }
 }
 
 void AGardenSandboxCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)

--- a/Source/GardenSandbox/GardenSandboxCharacter.h
+++ b/Source/GardenSandbox/GardenSandboxCharacter.h
@@ -44,9 +44,29 @@ class AGardenSandboxCharacter : public ACharacter
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=Input, meta=(AllowPrivateAccess = "true"))
 	UInputAction* MoveAction;
 
-	/** Look Input Action */
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+        /** Look Input Action */
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
         class UInputAction* LookAction;
+
+        /** Mapping context used while building */
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+        UInputMappingContext* BuildMappingContext;
+
+        /** Action to start building mode */
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+        UInputAction* StartBuildingAction;
+
+        /** Action to place a building */
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+        UInputAction* PlaceBuildingAction;
+
+        /** Action to cancel building placement */
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+        UInputAction* CancelBuildingAction;
+
+        /** Optional action to rotate a placed building */
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+        UInputAction* RotateBuildingAction;
 
         /** Building Component */
         UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Building, meta = (AllowPrivateAccess = "true"))


### PR DESCRIPTION
## Summary
- add building input properties to `AGardenSandboxCharacter`
- forward those properties to the `BuildingComponent` when attaching

## Testing
- `echo "No tests configured"`


------
https://chatgpt.com/codex/tasks/task_e_6841e75b3e0c8331babde8f1246e7344