### PR TITLE
Add IState interface and integrate with state machine

### DIFF
--- a/Source/GardenSandbox/State.h
+++ b/Source/GardenSandbox/State.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Interface.h"
+#include "State.generated.h"
+
+UINTERFACE(BlueprintType)
+class GARDENSANDBOX_API UState : public UInterface
+{
+    GENERATED_BODY()
+};
+
+class GARDENSANDBOX_API IState
+{
+    GENERATED_BODY()
+
+public:
+    virtual void Enter() = 0;
+    virtual void Execute() = 0;
+    virtual void Exit() = 0;
+};

--- a/Source/GardenSandbox/StateMachine.cpp
+++ b/Source/GardenSandbox/StateMachine.cpp
@@ -1,0 +1,28 @@
+#include "StateMachine.h"
+
+UStateMachine::UStateMachine()
+{
+}
+
+void UStateMachine::SetState(TScriptInterface<IState> NewState)
+{
+    if (CurrentState == NewState)
+    {
+        return;
+    }
+
+    TScriptInterface<IState> OldState = CurrentState;
+    if (CurrentState)
+    {
+        CurrentState->Exit();
+    }
+
+    CurrentState = NewState;
+
+    if (CurrentState)
+    {
+        CurrentState->Enter();
+    }
+
+    OnStateChanged.Broadcast(OldState, CurrentState);
+}

--- a/Source/GardenSandbox/StateMachine.h
+++ b/Source/GardenSandbox/StateMachine.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Object.h"
+#include "State.h"
+#include "StateMachine.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnStateChanged, TScriptInterface<IState>, OldState, TScriptInterface<IState>, NewState);
+
+UCLASS(Blueprintable, BlueprintType)
+class GARDENSANDBOX_API UStateMachine : public UObject
+{
+    GENERATED_BODY()
+public:
+    UStateMachine();
+
+    UPROPERTY(BlueprintAssignable, Category="State")
+    FOnStateChanged OnStateChanged;
+
+    UPROPERTY()
+    TScriptInterface<IState> CurrentState;
+
+    UFUNCTION(BlueprintCallable, Category="State")
+    void SetState(TScriptInterface<IState> NewState);
+};


### PR DESCRIPTION
## Summary
- define `UState`/`IState` interface with `Enter`, `Execute` and `Exit` methods
- refactor `UStateMachine` to use `IState` references instead of an enum
- broadcast old and new interface instances on state changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844676b5a24833187ed78d3fc2a7051