### PR TITLE
Load input actions in character constructor

### DIFF
--- a/Source/GardenSandbox/GardenSandboxCharacter.h
+++ b/Source/GardenSandbox/GardenSandboxCharacter.h
@@ -48,25 +48,6 @@ class AGardenSandboxCharacter : public ACharacter
         UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
         class UInputAction* LookAction;
 
-        /** Mapping context used while building */
-        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
-        UInputMappingContext* BuildMappingContext;
-
-        /** Action to start building mode */
-        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
-        UInputAction* StartBuildingAction;
-
-        /** Action to place a building */
-        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
-        UInputAction* PlaceBuildingAction;
-
-        /** Action to cancel building placement */
-        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
-        UInputAction* CancelBuildingAction;
-
-        /** Optional action to rotate a placed building */
-        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
-        UInputAction* RotateBuildingAction;
 
 public:
         /** Building Component */


### PR DESCRIPTION
## Summary
- load building input actions directly into the BuildingComponent
- remove redundant building input properties from `AGardenSandboxCharacter`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68447a5f65c08331aa64715ed640c8f2