### PR TITLE
Enable replication for buildings

### DIFF
--- a/Source/GardenSandbox/Buildings/GardenGhostBuildingBase.cpp
+++ b/Source/GardenSandbox/Buildings/GardenGhostBuildingBase.cpp
@@ -1,8 +1,11 @@
-#include "Buildings/GardenGhostBuildingBase.h"
+#include "GardenGhostBuildingBase.h"
 #include "Components/StaticMeshComponent.h"
 
 AGardenGhostBuildingBase::AGardenGhostBuildingBase()
 {
+    bReplicates = false;
+    SetReplicateMovement(false);
+
     if (MeshComponent)
     {
         MeshComponent->SetCollisionEnabled(ECollisionEnabled::NoCollision);

--- a/Source/GardenSandbox/Buildings/GardenStructure.cpp
+++ b/Source/GardenSandbox/Buildings/GardenStructure.cpp
@@ -1,4 +1,4 @@
-#include "Buildings/GardenStructure.h"
+#include "GardenStructure.h"
 
 AGardenStructure::AGardenStructure()
 {

--- a/Source/GardenSandbox/Buildings/GardenStructureGhost.cpp
+++ b/Source/GardenSandbox/Buildings/GardenStructureGhost.cpp
@@ -1,4 +1,4 @@
-#include "Buildings/GardenStructureGhost.h"
+#include "GardenStructureGhost.h"
 
 AGardenStructureGhost::AGardenStructureGhost()
 {

--- a/Source/GardenSandbox/Buildings/GardenStructureGhost.h
+++ b/Source/GardenSandbox/Buildings/GardenStructureGhost.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Buildings/GardenGhostBuildingBase.h"
+#include "GardenGhostBuildingBase.h"
 #include "GardenStructureGhost.generated.h"
 
 /** Ghost class for AGardenStructure used during placement */

--- a/Source/GardenSandbox/GardenBuildingBase.cpp
+++ b/Source/GardenSandbox/GardenBuildingBase.cpp
@@ -6,6 +6,9 @@ AGardenBuildingBase::AGardenBuildingBase()
 {
     PrimaryActorTick.bCanEverTick = false;
 
+    bReplicates = true;
+    SetReplicateMovement(true);
+
     MeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("MeshComponent"));
     RootComponent = MeshComponent;
 

--- a/Source/GardenSandbox/GardenSandboxCharacter.cpp
+++ b/Source/GardenSandbox/GardenSandboxCharacter.cpp
@@ -36,7 +36,7 @@ AGardenSandboxCharacter::AGardenSandboxCharacter()
        if (BuildMC.Succeeded())
        {
                LoadedBuildMapping = BuildMC.Object;
-
+       }
 
        // Load input actions
        static ConstructorHelpers::FObjectFinder<UInputAction> JumpAct(TEXT("/Game/FirstPerson/Input/Actions/IA_Jump.IA_Jump"));

--- a/Source/GardenSandbox/GardenSandboxGameMode.cpp
+++ b/Source/GardenSandbox/GardenSandboxGameMode.cpp
@@ -12,3 +12,4 @@ AGardenSandboxGameMode::AGardenSandboxGameMode()
 	DefaultPawnClass = PlayerPawnClassFinder.Class;
 
 }
+

--- a/Source/GardenSandbox/GardenSandboxPickUpComponent.cpp
+++ b/Source/GardenSandbox/GardenSandboxPickUpComponent.cpp
@@ -7,8 +7,8 @@
 
 UGardenSandboxPickUpComponent::UGardenSandboxPickUpComponent()
 {
-	// Setup the Sphere Collision
-	SphereRadius = 32.f;
+        // Setup the Sphere Collision
+        SetSphereRadius(32.f);
 }
 
 void UGardenSandboxPickUpComponent::BeginPlay()


### PR DESCRIPTION
## Summary
- enable replication on `AGardenBuildingBase`
- disable replication for `AGardenGhostBuildingBase`
- fix compile errors in `AGardenSandboxCharacter` and `UGardenSandboxPickUpComponent`
- add missing newline for `AGardenSandboxGameMode`
- correct include paths in building classes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68449b32781c83318b2ba0e22ea697d0