### PR TITLE
Add placement validity color change to structure ghost

### DIFF
--- a/Source/GardenSandbox/BuildingComponent.cpp
+++ b/Source/GardenSandbox/BuildingComponent.cpp
@@ -85,7 +85,6 @@ void UBuildingComponent::StartPlacement()
                 Prim->SetCollisionEnabled(ECollisionEnabled::NoCollision);
             }
         }
-        GhostActor->GetComponents<UMeshComponent>(GhostMeshComponents);
         UpdateGhostVisual();
         bIsPlacing = true;
         CurrentYaw = 0.f;
@@ -111,7 +110,6 @@ void UBuildingComponent::Place()
     FRotator Rot = GhostActor->GetActorRotation();
     GhostActor->Destroy();
     GhostActor = nullptr;
-    GhostMeshComponents.Empty();
     bPlacementValid = true;
 
     if (Character && Character->ResourceComponent)
@@ -137,7 +135,6 @@ void UBuildingComponent::Cancel()
             GhostActor->Destroy();
             GhostActor = nullptr;
         }
-        GhostMeshComponents.Empty();
         bPlacementValid = true;
         bIsPlacing = false;
     }
@@ -250,21 +247,9 @@ void UBuildingComponent::UpdateGhostVisual()
     if (bPlacementValid != bNewValid)
     {
         bPlacementValid = bNewValid;
-        for (UMeshComponent* Mesh : GhostMeshComponents)
+        if (GhostActor)
         {
-            if (!Mesh)
-            {
-                continue;
-            }
-            UMaterialInterface* Mat = bPlacementValid ? ValidPlacementMaterial : InvalidPlacementMaterial;
-            if (Mat)
-            {
-                int32 Count = Mesh->GetNumMaterials();
-                for (int32 i = 0; i < Count; ++i)
-                {
-                    Mesh->SetMaterial(i, Mat);
-                }
-            }
+            GhostActor->SetPlacementValid(bPlacementValid);
         }
     }
 }

--- a/Source/GardenSandbox/BuildingComponent.h
+++ b/Source/GardenSandbox/BuildingComponent.h
@@ -10,7 +10,6 @@ class AGardenSandboxCharacter;
 class UInputAction;
 class UInputMappingContext;
 class UMaterialInterface;
-class UMeshComponent;
 class UBuildingDataAsset;
 class AGardenBuildingBase;
 
@@ -74,7 +73,6 @@ private:
     AGardenSandboxCharacter* Character;
     bool bIsPlacing;
     float CurrentYaw;
-    TArray<UMeshComponent*> GhostMeshComponents;
     bool bPlacementValid;
 
     void UpdateGhostVisual();

--- a/Source/GardenSandbox/Buildings/GardenStructureGhost.cpp
+++ b/Source/GardenSandbox/Buildings/GardenStructureGhost.cpp
@@ -1,6 +1,45 @@
 #include "GardenStructureGhost.h"
-
+#include "Components/MeshComponent.h"
+#include "UObject/ConstructorHelpers.h"
 
 AGardenStructureGhost::AGardenStructureGhost()
+    : ValidMaterial(nullptr)
+    , InvalidMaterial(nullptr)
 {
+    static ConstructorHelpers::FObjectFinder<UMaterialInterface> ValidMatObj(TEXT("/Game/Materials/Ghost/BuildingGhostMaterial_Green.BuildingGhostMaterial_Green"));
+    if (ValidMatObj.Succeeded())
+    {
+        ValidMaterial = ValidMatObj.Object;
+    }
+
+    static ConstructorHelpers::FObjectFinder<UMaterialInterface> InvalidMatObj(TEXT("/Game/Materials/Ghost/BuildingGhostMaterial_Green.BuildingGhostMaterial_Red"));
+    if (InvalidMatObj.Succeeded())
+    {
+        InvalidMaterial = InvalidMatObj.Object;
+    }
+}
+
+void AGardenStructureGhost::SetPlacementValid(bool bIsValid)
+{
+    UMaterialInterface* Mat = bIsValid ? ValidMaterial : InvalidMaterial;
+    if (!Mat)
+    {
+        return;
+    }
+
+    TArray<UMeshComponent*> MeshComponents;
+    GetComponents(MeshComponents);
+    for (UMeshComponent* Mesh : MeshComponents)
+    {
+        if (!Mesh)
+        {
+            continue;
+        }
+
+        int32 Count = Mesh->GetNumMaterials();
+        for (int32 i = 0; i < Count; ++i)
+        {
+            Mesh->SetMaterial(i, Mat);
+        }
+    }
 }

--- a/Source/GardenSandbox/Buildings/GardenStructureGhost.h
+++ b/Source/GardenSandbox/Buildings/GardenStructureGhost.h
@@ -12,4 +12,19 @@ class GARDENSANDBOX_API AGardenStructureGhost : public AGardenBuildingBase
 public:
     AGardenStructureGhost();
 
+    /**
+     * Change ghost material based on placement validity
+     */
+    UFUNCTION(BlueprintCallable, Category="Building")
+    void SetPlacementValid(bool bIsValid);
+
+protected:
+    /** Material used for valid placement */
+    UPROPERTY()
+    UMaterialInterface* ValidMaterial;
+
+    /** Material used for invalid placement */
+    UPROPERTY()
+    UMaterialInterface* InvalidMaterial;
+
 };


### PR DESCRIPTION
## Summary
- load default placement materials in `AGardenStructureGhost`
- add `SetPlacementValid` to swap ghost material depending on validity
- call the new ghost method from `UBuildingComponent`
- remove unused ghost mesh component tracking

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68458b9846388331a27d4661215b49ef